### PR TITLE
[WIP] Opinionated deployment of enhanced Requalify capabilities on AInvs

### DIFF
--- a/proof/invariant-abstract/AARCH64/ArchADT_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchADT_AI.thy
@@ -12,7 +12,7 @@ imports
   "Lib.Simulation"
   Invariants_AI
 begin
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 subsection \<open>Constructing a virtual-memory view\<close>
 

--- a/proof/invariant-abstract/AARCH64/ArchAInvsPre.thy
+++ b/proof/invariant-abstract/AARCH64/ArchAInvsPre.thy
@@ -11,9 +11,7 @@ begin
 
 unbundle l4v_word_context
 
-context Arch begin
-
-global_naming AARCH64
+context Arch begin arch_global_naming
 
 lemma ucast_ucast_mask_low: "(ucast (x && mask asid_low_bits) :: asid_low_index) = ucast x"
   by (rule ucast_mask_drop, simp add: asid_low_bits_def)
@@ -143,9 +141,10 @@ proof goal_cases
   case 1 show ?case by (intro_locales; (unfold_locales; fact AInvsPre_assms)?)
 qed
 
-requalify_facts
-  AARCH64.user_mem_dom_cong
-  AARCH64.device_mem_dom_cong
-  AARCH64.device_frame_in_device_region
+(* FIXME arch_split: move to global theory *)
+arch_requalify_facts
+  user_mem_dom_cong
+  device_mem_dom_cong
+  device_frame_in_device_region
 
 end

--- a/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchAcc_AI.thy
@@ -17,7 +17,7 @@ lemma valid_vso_at[wp]:"\<lbrace>valid_vso_at level p\<rbrace> f \<lbrace>\<lamb
 
 end
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 (* Is there a lookup that leads to a page table at (level, p)? *)
 locale_abbrev ex_vs_lookup_table ::

--- a/proof/invariant-abstract/AARCH64/ArchArch_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchArch_AI.thy
@@ -11,7 +11,7 @@ begin
 
 unbundle l4v_word_context
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 definition
   "valid_aci aci \<equiv> case aci of MakePool frame slot parent base \<Rightarrow>
@@ -414,7 +414,7 @@ lemma equal_kernel_mappings:
 end
 
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 lemma vmid_for_asid_empty_update:
   "\<lbrakk> asid_table s asid_high = None; asid_pools_of s ap = Some Map.empty \<rbrakk> \<Longrightarrow>
@@ -1726,20 +1726,16 @@ lemma arch_pinv_st_tcb_at:
 
 end
 
-
-context begin interpretation Arch .
-
-requalify_consts
+(* FIXME arch_split: move to global theory *)
+arch_requalify_consts
   valid_arch_inv
 
-requalify_facts
+arch_requalify_facts
   invoke_arch_tcb
   invoke_arch_invs
   sts_valid_arch_inv
   arch_decode_inv_wf
   arch_pinv_st_tcb_at
-
-end
 
 declare invoke_arch_invs[wp]
 declare arch_decode_inv_wf[wp]

--- a/proof/invariant-abstract/AARCH64/ArchBCorres2_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchBCorres2_AI.thy
@@ -10,7 +10,7 @@ imports
   BCorres2_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 named_theorems BCorres2_AI_assms
 
@@ -89,7 +89,7 @@ interpretation BCorres2_AI?: BCorres2_AI
 
 lemmas schedule_bcorres[wp] = schedule_bcorres1[OF BCorres2_AI_axioms]
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 crunch send_ipc,send_signal,do_reply_transfer,arch_perform_invocation
   for (bcorres) bcorres[wp]: truncate_state

--- a/proof/invariant-abstract/AARCH64/ArchBCorres_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchBCorres_AI.thy
@@ -11,7 +11,7 @@ imports
   ArchBitSetup_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 lemma entry_for_asid_truncate[simp]:
   "entry_for_asid asid (truncate_state s) = entry_for_asid asid s"
@@ -45,7 +45,7 @@ crunch prepare_thread_delete
 
 end
 
-requalify_facts AARCH64.arch_finalise_cap_bcorres AARCH64.prepare_thread_delete_bcorres
+arch_requalify_facts arch_finalise_cap_bcorres prepare_thread_delete_bcorres
 
 declare arch_finalise_cap_bcorres[wp] prepare_thread_delete_bcorres[wp]
 

--- a/proof/invariant-abstract/AARCH64/ArchBits_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchBits_AI.thy
@@ -9,7 +9,7 @@ theory ArchBits_AI
 imports Invariants_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 (* arch-specific interpretations of update locales: *)
 

--- a/proof/invariant-abstract/AARCH64/ArchCNodeInv_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCNodeInv_AI.thy
@@ -9,7 +9,7 @@ theory ArchCNodeInv_AI
 imports CNodeInv_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 named_theorems CNodeInv_AI_assms
 
@@ -538,7 +538,7 @@ qed
 termination rec_del by (rule rec_del_termination)
 
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 lemma post_cap_delete_pre_is_final_cap':
   "\<lbrakk>valid_ioports s; caps_of_state s slot = Some cap; is_final_cap' cap s; cap_cleanup_opt cap \<noteq> NullCap\<rbrakk>
@@ -800,7 +800,7 @@ global_interpretation CNodeInv_AI_2?: CNodeInv_AI_2
   qed
 
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 lemma finalise_cap_rvk_prog [CNodeInv_AI_assms]:
    "finalise_cap cap f \<lbrace>\<lambda>s. revoke_progress_ord m (\<lambda>x. map_option cap_to_rpo (caps_of_state s x))\<rbrace>"
@@ -905,7 +905,7 @@ termination cap_revoke by (rule cap_revoke_termination)
 declare cap_revoke.simps[simp del]
 
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 crunch finalise_slot
   for typ_at[wp, CNodeInv_AI_assms]: "\<lambda>s. P (typ_at T p s)"
@@ -930,7 +930,7 @@ global_interpretation CNodeInv_AI_4?: CNodeInv_AI_4
   qed
 
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 lemma cap_move_ioports:
   "\<lbrace>valid_ioports and cte_wp_at ((=) cap.NullCap) ptr'

--- a/proof/invariant-abstract/AARCH64/ArchCSpaceInvPre_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCSpaceInvPre_AI.thy
@@ -14,7 +14,7 @@ imports CSpaceInvPre_AI
 begin
 
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 lemma aobj_ref_acap_rights_update[simp]:
   "aobj_ref (acap_rights_update f x) = aobj_ref x"

--- a/proof/invariant-abstract/AARCH64/ArchCSpaceInv_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCSpaceInv_AI.thy
@@ -12,7 +12,7 @@ theory ArchCSpaceInv_AI
 imports CSpaceInv_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 definition
    safe_ioport_insert :: "cap \<Rightarrow> cap \<Rightarrow> 'a::state_ext state \<Rightarrow> bool"
@@ -210,8 +210,6 @@ lemmas cap_vptr_simps [simp] =
 
 end
 
-context begin interpretation Arch .
-requalify_facts replace_cap_invs
-end
+arch_requalify_facts replace_cap_invs
 
 end

--- a/proof/invariant-abstract/AARCH64/ArchCSpacePre_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCSpacePre_AI.thy
@@ -13,7 +13,7 @@ theory ArchCSpacePre_AI
 imports CSpacePre_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 lemmas typ_at_eq_kheap_obj = typ_at_eq_kheap_obj atyp_at_eq_kheap_obj
 

--- a/proof/invariant-abstract/AARCH64/ArchCSpace_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCSpace_AI.thy
@@ -12,7 +12,7 @@ theory ArchCSpace_AI
 imports CSpace_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 named_theorems CSpace_AI_assms
 
@@ -304,7 +304,7 @@ end
 global_interpretation cap_insert_crunches?: cap_insert_crunches .
 
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 lemma cap_insert_cap_refs_in_kernel_window[wp, CSpace_AI_assms]:
   "\<lbrace>cap_refs_in_kernel_window
@@ -496,7 +496,7 @@ proof goal_cases
 qed
 
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 lemma is_cap_simps':
   "is_cnode_cap cap = (\<exists>r bits g. cap = cap.CNodeCap r bits g)"
@@ -599,12 +599,9 @@ lemma set_cap_kernel_window_simple:
 
 end
 
-context begin interpretation Arch .
-
-requalify_facts
+(* FIXME arch_split: move to non-Arch theory? *)
+arch_requalify_facts
   set_cap_valid_arch_caps_simple
   set_cap_kernel_window_simple
-
-end
 
 end

--- a/proof/invariant-abstract/AARCH64/ArchCrunchSetup_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchCrunchSetup_AI.thy
@@ -10,7 +10,7 @@ imports
   "Lib.Crunch_Instances_NonDet"
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 crunch_ignore (add: debugPrint clearMemory pt_lookup_from_level)
 

--- a/proof/invariant-abstract/AARCH64/ArchDetSchedAux_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetSchedAux_AI.thy
@@ -9,7 +9,7 @@ theory ArchDetSchedAux_AI
 imports DetSchedAux_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 named_theorems DetSchedAux_AI_assms
 

--- a/proof/invariant-abstract/AARCH64/ArchDetSchedDomainTime_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetSchedDomainTime_AI.thy
@@ -9,7 +9,7 @@ theory ArchDetSchedDomainTime_AI
 imports DetSchedDomainTime_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 named_theorems DetSchedDomainTime_AI_assms
 
@@ -62,7 +62,7 @@ proof goal_cases
   case 1 show ?case by (unfold_locales; (fact DetSchedDomainTime_AI_assms)?)
 qed
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 crunch arch_perform_invocation
   for domain_time_inv[wp, DetSchedDomainTime_AI_assms]: "\<lambda>s. P (domain_time s)"

--- a/proof/invariant-abstract/AARCH64/ArchDetSchedSchedule_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetSchedSchedule_AI.thy
@@ -9,7 +9,7 @@ theory ArchDetSchedSchedule_AI
 imports DetSchedSchedule_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 named_theorems DetSchedSchedule_AI_assms
 
@@ -498,7 +498,7 @@ proof goal_cases
   case 1 show ?case by (unfold_locales; (fact DetSchedSchedule_AI_assms)?)
 qed
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 lemma dmo_scheduler_act_sane[wp]:
   "\<lbrace>scheduler_act_sane\<rbrace> do_machine_op f \<lbrace>\<lambda>rv. scheduler_act_sane\<rbrace>"

--- a/proof/invariant-abstract/AARCH64/ArchDeterministic_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDeterministic_AI.thy
@@ -11,7 +11,7 @@ begin
 
 declare dxo_wp_weak[wp del]
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 named_theorems Deterministic_AI_assms
 
@@ -40,7 +40,7 @@ proof goal_cases
   case 1 show ?case by (unfold_locales; (fact Deterministic_AI_assms)?)
 qed
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 crunch arch_invoke_irq_handler
   for valid_list[wp,Deterministic_AI_assms]: valid_list

--- a/proof/invariant-abstract/AARCH64/ArchDetype_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchDetype_AI.thy
@@ -9,7 +9,7 @@ theory ArchDetype_AI
 imports Detype_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 named_theorems Detype_AI_assms
 
@@ -636,8 +636,8 @@ interpretation Detype_AI_2
         Detype_AI_2.intro
         by blast
 
-context begin interpretation Arch .
-lemma delete_objects_invs[wp]:
+(* generic consequence of architecture-specific details *)
+lemma (in Arch) delete_objects_invs[wp]:
   "\<lbrace>(\<lambda>s. \<exists>slot. cte_wp_at ((=) (cap.UntypedCap dev ptr bits f)) slot s
     \<and> descendants_range (cap.UntypedCap dev ptr bits f) slot s) and
     invs and ct_active\<rbrace>
@@ -657,6 +657,8 @@ lemma delete_objects_invs[wp]:
   apply (drule (1) cte_wp_valid_cap)
   apply (simp add: valid_cap_def cap_aligned_def word_size_bits_def untyped_min_bits_def)
   done
-end
+
+requalify_facts Arch.delete_objects_invs
+lemmas [wp] = delete_objects_invs
 
 end

--- a/proof/invariant-abstract/AARCH64/ArchEmptyFail_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchEmptyFail_AI.thy
@@ -9,7 +9,7 @@ theory ArchEmptyFail_AI
 imports EmptyFail_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 named_theorems EmptyFail_AI_assms
 
@@ -30,7 +30,7 @@ global_interpretation EmptyFail_AI_load_word?: EmptyFail_AI_load_word
   case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
   qed
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 crunch handle_fault
   for (empty_fail) empty_fail[wp, EmptyFail_AI_assms]
@@ -128,7 +128,7 @@ proof goal_cases
   case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
 qed
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 lemma empty_fail_pt_lookup_from_level[wp]:
   "empty_fail (pt_lookup_from_level level pt_ptr vptr target_pt_ptr)"
@@ -158,7 +158,7 @@ proof goal_cases
   case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
 qed
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 crunch
   cap_delete, choose_thread
   for (empty_fail) empty_fail[wp, EmptyFail_AI_assms]
@@ -182,7 +182,7 @@ proof goal_cases
   case 1 show ?case by (unfold_locales; (fact EmptyFail_AI_assms)?)
 qed
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 lemma plic_complete_claim_empty_fail[wp, EmptyFail_AI_assms]:
   "empty_fail (plic_complete_claim irq)"

--- a/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchFinalise_AI.thy
@@ -9,11 +9,9 @@ theory ArchFinalise_AI
 imports Finalise_AI
 begin
 
-context Arch begin
+context Arch begin arch_global_naming
 
 named_theorems Finalise_AI_assms
-
-global_naming AARCH64
 
 lemma valid_global_refs_asid_table_udapte [iff]:
   "valid_global_refs (s\<lparr>arch_state := arm_asid_table_update f (arch_state s)\<rparr>) =
@@ -1581,7 +1579,7 @@ interpretation Finalise_AI_1?: Finalise_AI_1
     by (intro_locales; (unfold_locales; fact Finalise_AI_assms)?)
   qed
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 lemma fast_finalise_replaceable[wp]:
   "\<lbrace>\<lambda>s. s \<turnstile> cap \<and> x = is_final_cap' cap s
@@ -1620,7 +1618,7 @@ interpretation Finalise_AI_2?: Finalise_AI_2
   case 1 show ?case by (intro_locales; (unfold_locales; fact Finalise_AI_assms)?)
   qed
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 crunch
   vcpu_update, vgic_update, vcpu_disable, vcpu_restore, vcpu_save_reg_range, vgic_update_lr,
@@ -1753,7 +1751,7 @@ lemma invs_valid_arch_capsI:
   "invs s \<Longrightarrow> valid_arch_caps s"
   by (simp add: invs_def valid_state_def)
 
-context Arch begin global_naming AARCH64 (*FIXME: arch_split*)
+context Arch begin arch_global_naming (*FIXME: arch_split*)
 
 lemma do_machine_op_reachable_pg_cap[wp]:
   "\<lbrace>\<lambda>s. P (reachable_frame_cap cap s)\<rbrace>
@@ -1900,9 +1898,7 @@ lemma (* dmo_replaceable_or_arch_update *) [Finalise_AI_assms,wp]:
 
 end
 
-context begin interpretation Arch .
-requalify_consts replaceable_or_arch_update
-end
+arch_requalify_consts replaceable_or_arch_update
 
 interpretation Finalise_AI_3?: Finalise_AI_3
   where replaceable_or_arch_update = replaceable_or_arch_update
@@ -1912,7 +1908,7 @@ interpretation Finalise_AI_3?: Finalise_AI_3
     by (intro_locales; (unfold_locales; fact Finalise_AI_assms)?)
   qed
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 lemma typ_at_data_at_wp:
   assumes typ_wp: "\<And>a.\<lbrace>typ_at a p \<rbrace> g \<lbrace>\<lambda>s. typ_at a p\<rbrace>"
@@ -1930,7 +1926,7 @@ interpretation Finalise_AI_4?: Finalise_AI_4
   case 1 show ?case by (intro_locales; (unfold_locales; fact Finalise_AI_assms)?)
   qed
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 lemma set_asid_pool_obj_at_ptr:
   "\<lbrace>\<lambda>s. P (ArchObj (arch_kernel_obj.ASIDPool mp))\<rbrace>

--- a/proof/invariant-abstract/AARCH64/ArchInterruptAcc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInterruptAcc_AI.thy
@@ -12,7 +12,7 @@ theory ArchInterruptAcc_AI
 imports InterruptAcc_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 named_theorems InterruptAcc_AI_assms
 

--- a/proof/invariant-abstract/AARCH64/ArchInterrupt_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInterrupt_AI.thy
@@ -9,7 +9,7 @@ theory ArchInterrupt_AI
 imports Interrupt_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 primrec arch_irq_control_inv_valid_real ::
   "arch_irq_control_invocation \<Rightarrow> 'a::state_ext state \<Rightarrow> bool"

--- a/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchInvariants_AI.thy
@@ -9,7 +9,7 @@ theory ArchInvariants_AI
 imports InvariantsPre_AI "Eisbach_Tools.Apply_Trace_Cmd"
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 (* compatibility with other architectures, input only *)
 abbreviation
@@ -29,7 +29,7 @@ record iarch_tcb =
   itcb_vcpu :: "obj_ref option"
 end_qualify
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 definition arch_tcb_to_iarch_tcb :: "arch_tcb \<Rightarrow> iarch_tcb" where
   "arch_tcb_to_iarch_tcb arch_tcb \<equiv> \<lparr> itcb_vcpu = tcb_vcpu arch_tcb \<rparr>"

--- a/proof/invariant-abstract/AARCH64/ArchIpcCancel_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchIpcCancel_AI.thy
@@ -8,7 +8,7 @@ theory ArchIpcCancel_AI
 imports IpcCancel_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 named_theorems IpcCancel_AI_assms
 

--- a/proof/invariant-abstract/AARCH64/ArchIpc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchIpc_AI.thy
@@ -9,7 +9,7 @@ theory ArchIpc_AI
 imports Ipc_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 named_theorems Ipc_AI_assms
 
@@ -499,7 +499,7 @@ proof goal_cases
   case 1 show ?case by (unfold_locales; (fact Ipc_AI_assms)?)
 qed
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 named_theorems Ipc_AI_cont_assms
 

--- a/proof/invariant-abstract/AARCH64/ArchKHeap_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchKHeap_AI.thy
@@ -9,7 +9,7 @@ theory ArchKHeap_AI
 imports KHeapPre_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 definition non_vspace_obj :: "kernel_object \<Rightarrow> bool" where
   "non_vspace_obj ko \<equiv> case ko of
@@ -129,7 +129,7 @@ locale vspace_only_obj_pred = Arch +
 sublocale vspace_only_obj_pred < arch_only_obj_pred
   using vspace_pred_imp[OF vspace_only] by unfold_locales
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 lemma valid_vspace_obj_lift:
   assumes "\<And>T p. T \<noteq> AVCPU \<Longrightarrow> f \<lbrace>typ_at (AArch T) p\<rbrace>"

--- a/proof/invariant-abstract/AARCH64/ArchKernelInit_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchKernelInit_AI.thy
@@ -12,7 +12,7 @@ imports
   Arch_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 text \<open>
   Showing that there is a state that satisfies the abstract invariants.

--- a/proof/invariant-abstract/AARCH64/ArchLevityCatch_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchLevityCatch_AI.thy
@@ -12,7 +12,7 @@ imports
   "Lib.SplitRule"
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 lemma asid_high_bits_of_shift[simp]:
   "asid_high_bits_of (ucast x << asid_low_bits) = x"

--- a/proof/invariant-abstract/AARCH64/ArchRetype_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchRetype_AI.thy
@@ -13,7 +13,7 @@ theory ArchRetype_AI
 imports Retype_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 named_theorems Retype_AI_assms
 
@@ -125,10 +125,7 @@ declare post_retype_invs_check_def[simp]
 
 end
 
-
-context begin interpretation Arch .
-requalify_consts post_retype_invs_check
-end
+arch_requalify_consts post_retype_invs_check
 
 definition
   post_retype_invs :: "apiobject_type \<Rightarrow> obj_ref list \<Rightarrow> 'z::state_ext state \<Rightarrow> bool"
@@ -144,7 +141,7 @@ global_interpretation Retype_AI_post_retype_invs?: Retype_AI_post_retype_invs
   by (unfold_locales; fact post_retype_invs_def)
 
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 lemma init_arch_objects_invs_from_restricted:
   "\<lbrace>post_retype_invs new_type refs
@@ -177,7 +174,7 @@ global_interpretation Retype_AI_slot_bits?: Retype_AI_slot_bits
   qed
 
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 lemma valid_untyped_helper [Retype_AI_assms]:
   assumes valid_c : "s  \<turnstile> c"
@@ -274,6 +271,7 @@ locale retype_region_proofs_arch
 
 context retype_region_proofs begin
 
+(* FIXME arch_split: is there any way to optimise this interpretation out? we can't nest contexts *)
 interpretation Arch .
 
 lemma valid_cap:
@@ -580,7 +578,7 @@ sublocale retype_region_proofs_gen?: retype_region_proofs_gen
 end
 
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 lemma unique_table_caps_null:
   "unique_table_caps_2 (null_filter caps)
@@ -683,9 +681,7 @@ lemma cap_range_respects_device_region_cong[cong]:
   by (clarsimp simp: cap_range_respects_device_region_def)
 
 
-context begin interpretation Arch .
-requalify_consts region_in_kernel_window
-end
+arch_requalify_consts region_in_kernel_window
 
 
 context retype_region_proofs_arch begin
@@ -875,7 +871,7 @@ lemmas post_retype_invs_axioms = retype_region_proofs_invs_axioms
 end
 
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 named_theorems Retype_AI_assms'
 
@@ -905,7 +901,7 @@ global_interpretation Retype_AI?: Retype_AI
   qed
 
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 lemma retype_region_plain_invs:
   "\<lbrace>invs and caps_no_overlap ptr sz and pspace_no_overlap_range_cover ptr sz

--- a/proof/invariant-abstract/AARCH64/ArchSchedule_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchSchedule_AI.thy
@@ -9,7 +9,7 @@ theory ArchSchedule_AI
 imports Schedule_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 named_theorems Schedule_AI_assms
 
@@ -28,6 +28,7 @@ lemma dmo_mapM_storeWord_0_invs[wp,Schedule_AI_assms]:
    apply wp
   by (simp add: upto.simps word_bits_def)
 
+(* FIXME arch_split: why not arch global naming? this doesn't make sense *)
 global_naming Arch
 
 lemma arch_stt_invs [wp,Schedule_AI_assms]:

--- a/proof/invariant-abstract/AARCH64/ArchSyscall_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchSyscall_AI.thy
@@ -14,7 +14,7 @@ imports
   Syscall_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 named_theorems Syscall_AI_assms
 

--- a/proof/invariant-abstract/AARCH64/ArchTcbAcc_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchTcbAcc_AI.thy
@@ -8,7 +8,7 @@ theory ArchTcbAcc_AI
 imports TcbAcc_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 named_theorems TcbAcc_AI_assms
 

--- a/proof/invariant-abstract/AARCH64/ArchTcb_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchTcb_AI.thy
@@ -9,7 +9,7 @@ theory ArchTcb_AI
 imports Tcb_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 named_theorems Tcb_AI_assms
 
@@ -159,7 +159,7 @@ proof goal_cases
   case 1 show ?case by (unfold_locales; (fact Tcb_AI_assms)?)
 qed
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 lemma use_no_cap_to_obj_asid_strg: (* arch specific *)
   "(cte_at p s \<and> no_cap_to_obj_dr_emp cap s \<and> valid_cap cap s \<and> invs s)
@@ -376,16 +376,15 @@ crunch invoke_tcb
 
 end
 
-context begin interpretation Arch .
-requalify_consts is_cnode_or_valid_arch
-requalify_facts invoke_tcb_typ_at
-end
-
 global_interpretation Tcb_AI?: Tcb_AI
   where is_cnode_or_valid_arch = AARCH64.is_cnode_or_valid_arch
 proof goal_cases
   interpret Arch .
   case 1 show ?case by (unfold_locales; (fact Tcb_AI_assms)?)
 qed
+
+(* FIXME arch_split: move to global theory *)
+arch_requalify_consts is_cnode_or_valid_arch
+arch_requalify_facts invoke_tcb_typ_at
 
 end

--- a/proof/invariant-abstract/AARCH64/ArchUntyped_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchUntyped_AI.thy
@@ -9,7 +9,7 @@ theory ArchUntyped_AI
 imports Untyped_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 named_theorems Untyped_AI_assms
 

--- a/proof/invariant-abstract/AARCH64/ArchVCPU_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchVCPU_AI.thy
@@ -9,7 +9,7 @@ theory ArchVCPU_AI
 imports AInvs
 begin
 
-context Arch begin global_naming AARCH64 (*FIXME: arch_split*)
+context Arch begin arch_global_naming (*FIXME: arch_split*)
 
 (* This is similar to cur_vcpu_2, but not close enough to reuse. *)
 definition active_cur_vcpu_of :: "'z state \<Rightarrow> obj_ref option" where

--- a/proof/invariant-abstract/AARCH64/ArchVSpaceEntries_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchVSpaceEntries_AI.thy
@@ -9,7 +9,7 @@ theory ArchVSpaceEntries_AI
 imports VSpaceEntries_AI
 begin
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 (* Since we're not doing anything with the index apart from returning it, this definition works
    for both, NormalPTs and VSRootPTs *)

--- a/proof/invariant-abstract/AARCH64/ArchVSpace_AI.thy
+++ b/proof/invariant-abstract/AARCH64/ArchVSpace_AI.thy
@@ -21,7 +21,7 @@ lemma valid_asid_map_upd[simp]:
 
 end
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 sublocale
   set_vcpu: non_vspace_non_cap_non_mem_op "set_vcpu p vcpu" +
@@ -2324,7 +2324,7 @@ lemma valid_vspace_obj:
 
 end
 
-context Arch begin global_naming AARCH64
+context Arch begin arch_global_naming
 
 lemma set_asid_pool_arch_objs_map:
   "\<lbrace>valid_vspace_objs and valid_arch_state and valid_global_objs and
@@ -3142,9 +3142,8 @@ crunch vcpu_switch
 
 end
 
-context begin interpretation Arch .
-requalify_facts
+(* FIXME arch_split: move to generic theory? *)
+arch_requalify_facts
   do_machine_op_valid_kernel_mappings
-end
 
 end

--- a/proof/invariant-abstract/AARCH64/Machine_AI.thy
+++ b/proof/invariant-abstract/AARCH64/Machine_AI.thy
@@ -69,6 +69,7 @@ crunch_ignore (no_irq) (add:
   handleE' handleE handle_elseE forM forM_x
   zipWithM ignore_failure)
 
+(* FIXME arch_split: no global_naming? *)
 context Arch begin
 
 text \<open>Deterministic\<close>
@@ -423,14 +424,10 @@ lemma dmo_gets_inv[wp]:
 
 end
 
-context begin interpretation Arch .
-
 requalify_facts
-  det_getRegister
-  det_setRegister
-  det_getRestartPC
-  det_setNextPC
-
-end
+  Arch.det_getRegister
+  Arch.det_setRegister
+  Arch.det_getRestartPC
+  Arch.det_setNextPC
 
 end

--- a/proof/invariant-abstract/ADT_AI.thy
+++ b/proof/invariant-abstract/ADT_AI.thy
@@ -11,17 +11,13 @@ imports
   ArchADT_AI
 begin
 
-context begin interpretation Arch .
-
-requalify_consts
+arch_requalify_consts (A)
   empty_context
   init_A_st
+
+arch_requalify_consts
   ptable_lift
   ptable_rights
-  addrFromPPtr
-  ptrFromPAddr
-
-end
 
 text \<open>
   The general refinement calculus (see theory Simulation) requires

--- a/proof/invariant-abstract/BCorres_AI.thy
+++ b/proof/invariant-abstract/BCorres_AI.thy
@@ -16,6 +16,16 @@ abbreviation "bcorres \<equiv> bcorres_underlying truncate_state"
 
 abbreviation "s_bcorres \<equiv> s_bcorres_underlying truncate_state"
 
+context Arch begin arch_global_naming
+
+crunch arch_post_cap_deletion
+  for (bcorres) bcorres[wp]: truncate_state
+
+end
+
+arch_requalify_facts
+  arch_post_cap_deletion_bcorres
+
 lemma dxo_bcorres[wp]:
   "bcorres (do_extended_op f) (do_extended_op f)"
   apply (simp add: do_extended_op_def)
@@ -62,16 +72,6 @@ lemma bcorres_select_ext[wp]:
   "bcorres (select_ext a A) (select_ext a A)"
   by (clarsimp simp: select_ext_def bind_def gets_def return_def select_def assert_def get_def
                      select_switch_unit_def bcorres_underlying_def s_bcorres_underlying_def fail_def)
-
-context Arch begin
-
-crunch arch_post_cap_deletion
-  for (bcorres) bcorres[wp]: truncate_state
-
-end
-
-requalify_facts
-  Arch.arch_post_cap_deletion_bcorres
 
 crunch
   set_original, set_object, set_cap, set_irq_state, deleted_irq_handler, get_cap,set_cdt, empty_slot

--- a/proof/invariant-abstract/CNodeInv_AI.thy
+++ b/proof/invariant-abstract/CNodeInv_AI.thy
@@ -13,14 +13,10 @@ theory CNodeInv_AI
 imports ArchIpc_AI
 begin
 
-
-context begin interpretation Arch .
-requalify_facts
-  set_cap_arch
+arch_requalify_facts
   cte_at_length_limit
   arch_derive_cap_untyped
   valid_arch_mdb_cap_swap
-end
 
 declare set_cap_arch[wp]
 

--- a/proof/invariant-abstract/CSpaceInvPre_AI.thy
+++ b/proof/invariant-abstract/CSpaceInvPre_AI.thy
@@ -8,17 +8,12 @@ theory CSpaceInvPre_AI
 imports ArchAcc_AI
 begin
 
-context begin interpretation Arch .
-
-requalify_consts
+arch_requalify_consts
   table_cap_ref
   empty_table
 
-requalify_facts
+arch_requalify_facts
   empty_table_def
-
-end
-
 
 lemma set_cap_caps_of_state[wp]:
   "\<lbrace>\<lambda>s. P ((caps_of_state s) (ptr \<mapsto> cap))\<rbrace> set_cap cap ptr \<lbrace>\<lambda>rv s. P (caps_of_state s)\<rbrace>"
@@ -141,8 +136,9 @@ lemma empty_table_caps_of:
   "empty_table S ko \<Longrightarrow> caps_of ko = {}"
   by (cases ko, simp_all add: empty_table_def caps_of_def cap_of_def)
 
-context begin interpretation Arch .
-lemma free_index_update_test_function_stuff[simp]:
+(* FIXME arch_split: exports properties of functions that are not necessarily in global context,
+   and then they get placed in the global simpset *)
+lemma (in Arch) free_index_update_test_function_stuff[simp]:
   "cap_asid (src_cap\<lparr>free_index := a\<rparr>) = cap_asid src_cap"
   "gen_obj_refs (src_cap\<lparr>free_index := a\<rparr>) = gen_obj_refs src_cap"
   "vs_cap_ref (src_cap\<lparr>free_index := a\<rparr>) = vs_cap_ref src_cap"
@@ -152,6 +148,9 @@ lemma free_index_update_test_function_stuff[simp]:
   by (auto simp: cap_asid_def free_index_update_def vs_cap_ref_def
                  is_cap_simps gen_obj_refs_def
           split: cap.splits arch_cap.splits)
-end
+
+requalify_facts Arch.free_index_update_test_function_stuff
+
+lemmas [simp] = free_index_update_test_function_stuff
 
 end

--- a/proof/invariant-abstract/CSpaceInv_AI.thy
+++ b/proof/invariant-abstract/CSpaceInv_AI.thy
@@ -12,31 +12,31 @@ theory CSpaceInv_AI
 imports ArchCSpaceInvPre_AI
 begin
 
-context begin interpretation Arch .
-
-requalify_consts
+arch_requalify_consts
   cap_master_arch_cap
   replaceable_final_arch_cap
   replaceable_non_final_arch_cap
   unique_table_refs
 
-requalify_facts
+(* There are multiple arch-dependent acap_rights_update_id, one for wellformed_acap,
+   one for valid_arch_cap. Prefer the latter. *)
+arch_requalify_facts (aliasing)
+  acap_rights_update_id
+
+arch_requalify_facts
   aobj_ref_acap_rights_update
   arch_obj_size_acap_rights_update
   valid_arch_cap_acap_rights_update
-  valid_validate_vm_rights
   cap_master_arch_inv
   unique_table_refs_def
   valid_ipc_buffer_cap_def
   acap_rights_update_idem
   cap_master_arch_cap_rights
-  acap_rights_update_id
   is_nondevice_page_cap_simps
   set_cap_hyp_refs_of
   state_hyp_refs_of_revokable
   set_cap_hyp_refs_of
   is_valid_vtable_root_is_arch_cap
-end
 
 lemma is_valid_vtable_root_simps[simp]:
   "\<not> is_valid_vtable_root (UntypedCap a b c d)"
@@ -1053,16 +1053,14 @@ lemma get_cap_caps_of_state:
   "(fst (get_cap p s) = {(cap, s)}) = (Some cap = caps_of_state s p)"
   by (clarsimp simp: caps_of_state_def eq_commute)
 
-context Arch begin
-
-lemma abj_ref_none_no_refs:
+(* generic consequence of architecture-specific details *)
+(* FIXME arch_split: no global naming? *)
+lemma (in Arch) abj_ref_none_no_refs:
   "obj_refs c = {} \<Longrightarrow> table_cap_ref c = None"
   unfolding table_cap_ref_def
   apply (cases c; simp)
   subgoal for ac by (cases ac; simp)
   done
-
-end
 
 requalify_facts Arch.abj_ref_none_no_refs
 

--- a/proof/invariant-abstract/CSpacePre_AI.thy
+++ b/proof/invariant-abstract/CSpacePre_AI.thy
@@ -12,15 +12,13 @@ theory CSpacePre_AI
 imports ArchCSpaceInv_AI
 begin
 
-context begin interpretation Arch .
-requalify_consts
+arch_requalify_consts
   cap_asid
   is_simple_cap_arch
   is_derived_arch
   safe_parent_for_arch
   cap_asid_base
   cap_vptr
-end
 
 lemma fun_upd_Some:
   "ms p = Some k \<Longrightarrow> (ms(a \<mapsto> b)) p = Some (if a = p then b else k)"

--- a/proof/invariant-abstract/CSpace_AI.thy
+++ b/proof/invariant-abstract/CSpace_AI.thy
@@ -12,25 +12,28 @@ theory CSpace_AI
 imports ArchCSpacePre_AI
 begin
 
-context begin interpretation Arch .
-
-requalify_consts
+arch_requalify_consts
   irq_state_update
   irq_state
   final_matters_arch
   ups_of_heap
 
+(* FIXME arch_split: this should maybe have a global_naming *)
 requalify_facts
+  Arch.loadWord_inv
+
+arch_requalify_facts (A)
+  update_cnode_cap_data_def
+
+arch_requalify_facts
   is_derived_arch_non_arch
   ups_of_heap_non_arch_upd
   master_arch_cap_obj_refs
   master_arch_cap_cap_class
   same_aobject_as_commute
   arch_derive_cap_inv
-  loadWord_inv
   valid_global_refsD2
   arch_derived_is_device
-  update_cnode_cap_data_def
   safe_parent_for_arch_not_arch
   safe_parent_cap_range_arch
   valid_arch_mdb_simple
@@ -43,8 +46,6 @@ requalify_facts
   valid_arch_mdb_same_master_cap
   valid_arch_mdb_null_filter
   valid_arch_mdb_untypeds
-
-end
 
 declare set_cap_update_free_index_valid_arch_mdb[wp]
 

--- a/proof/invariant-abstract/DetSchedAux_AI.thy
+++ b/proof/invariant-abstract/DetSchedAux_AI.thy
@@ -8,10 +8,9 @@ theory DetSchedAux_AI
 imports DetSchedInvs_AI
 begin
 
-context begin interpretation Arch .
+(* (* FIXME arch_split: check it's global on other arches *)
 requalify_facts
-  invoke_untyped_st_tcb_at
-end
+  invoke_untyped_st_tcb_at *)
 
 crunch_ignore (del:
   cap_swap_ext cap_move_ext cap_insert_ext empty_slot_ext create_cap_ext tcb_sched_action

--- a/proof/invariant-abstract/Deterministic_AI.thy
+++ b/proof/invariant-abstract/Deterministic_AI.thy
@@ -8,14 +8,12 @@ theory Deterministic_AI
 imports AInvs
 begin
 
-context begin interpretation Arch .
-requalify_facts
+arch_requalify_facts
   update_work_units_empty_fail
   reset_work_units_empty_fail
   set_domain_empty_fail
   thread_set_domain_empty_fail
   arch_post_cap_deletion_valid_list
-end
 
 lemmas [wp] =
   update_work_units_empty_fail

--- a/proof/invariant-abstract/Detype_AI.thy
+++ b/proof/invariant-abstract/Detype_AI.thy
@@ -8,17 +8,13 @@ theory Detype_AI
 imports ArchRetype_AI
 begin
 
-context begin interpretation Arch .
-
-requalify_facts
+arch_requalify_facts
   valid_arch_mdb_detype
   clearMemory_invs
   invs_irq_state_independent
   init_arch_objects_invs_from_restricted
   caps_region_kernel_window_imp
   init_arch_objects_wps
-
-end
 
 declare clearMemory_invs[wp]
 

--- a/proof/invariant-abstract/EmptyFail_AI.thy
+++ b/proof/invariant-abstract/EmptyFail_AI.thy
@@ -8,10 +8,9 @@ theory EmptyFail_AI
 imports ArchTcb_AI
 begin
 
-context begin interpretation Arch .
+(* FIXME arch_split: no global_naming *)
 requalify_facts
-  ef_machine_op_lift
-end
+  Arch.ef_machine_op_lift
 
 lemmas [wp] = ef_ignore_failure ef_machine_op_lift
 

--- a/proof/invariant-abstract/Finalise_AI.thy
+++ b/proof/invariant-abstract/Finalise_AI.thy
@@ -20,26 +20,25 @@ where
   | cap.Zombie r zb n         \<Rightarrow> {(r, replicate (zombie_cte_bits zb) False)}
   | _                         \<Rightarrow> {})"
 
-context begin interpretation Arch .
-
-requalify_consts
-  vs_cap_ref
+arch_requalify_consts (A)
   unmap_page
-  clearMemory
+
+arch_requalify_consts
+  vs_cap_ref
   arch_post_cap_delete_pre
 
+(* FIXME arch_split: no global_naming *)
 requalify_facts
+  Arch.no_irq_clearMemory
+
+arch_requalify_facts
   final_cap_lift
-  no_irq_clearMemory
   valid_global_refsD
-  valid_global_refsD2
   arch_post_cap_deletion_valid_objs
   arch_post_cap_deletion_cte_wp_at
   arch_post_cap_deletion_caps_of_state
   arch_post_cap_deletion_irq_node
   arch_post_cap_deletion_invs
-
-end
 
 definition
   "post_cap_delete_pre cap cs \<equiv> case cap of

--- a/proof/invariant-abstract/Interrupt_AI.thy
+++ b/proof/invariant-abstract/Interrupt_AI.thy
@@ -12,14 +12,8 @@ theory Interrupt_AI
 imports ArchIpc_AI
 begin
 
-
-context begin interpretation Arch .
-requalify_consts
-  maxIRQ
-
-requalify_facts
+arch_requalify_facts
   arch_post_cap_deletion_mdb_inv
-end
 
 definition
   interrupt_derived :: "cap \<Rightarrow> cap \<Rightarrow> bool"

--- a/proof/invariant-abstract/InvariantsPre_AI.thy
+++ b/proof/invariant-abstract/InvariantsPre_AI.thy
@@ -8,15 +8,12 @@ theory InvariantsPre_AI
 imports LevityCatch_AI
 begin
 
-context begin interpretation Arch .
-
-requalify_types
+(* FIXME RAF: these already appear exported to global context?!
+arch_requalify_types (A)
   aa_type
 
-requalify_consts
-  aa_type
-
-end
+arch_requalify_consts (A)
+  aa_type *)
 
 (* FIXME: move *)
 declare ranI [intro]

--- a/proof/invariant-abstract/Invariants_AI.thy
+++ b/proof/invariant-abstract/Invariants_AI.thy
@@ -9,16 +9,24 @@ theory Invariants_AI
 imports ArchInvariants_AI
 begin
 
-context begin interpretation Arch .
-
-requalify_types
+arch_requalify_types
   iarch_tcb
 
-requalify_consts
+arch_requalify_consts (A)
+  arch_cap_is_device
+  ASIDPoolObj
+
+(* we need to know the sizes of arch objects in the generic context *)
+arch_requalify_facts (A)
+  cte_level_bits_def
+  tcb_bits_def
+  endpoint_bits_def
+  ntfn_bits_def
+
+arch_requalify_consts
   not_kernel_window
   global_refs
   arch_obj_bits_type
-  arch_cap_is_device
   is_nondevice_page_cap
   state_hyp_refs_of
   hyp_refs_of
@@ -45,8 +53,6 @@ requalify_consts
   valid_global_vspace_mappings
   pspace_in_kernel_window
 
-  ASIDPoolObj
-
   valid_vs_lookup
   user_mem
   device_mem
@@ -59,7 +65,7 @@ requalify_consts
   vs_lookup
   vs_lookup_pages
 
-requalify_facts
+arch_requalify_facts
   valid_arch_sizes
   aobj_bits_T
   valid_arch_cap_def2
@@ -93,12 +99,13 @@ requalify_facts
   wellformed_arch_typ
   valid_arch_tcb_pspaceI
   valid_arch_tcb_lift
-  cte_level_bits_def
   obj_ref_not_arch_gen_ref
   arch_gen_ref_not_obj_ref
   arch_gen_obj_refs_inD
   same_aobject_same_arch_gen_refs
   valid_arch_mdb_eqI
+  iarch_tcb_context_set
+  iarch_tcb_set_registers
 
 lemmas [simp] =
   tcb_bits_def
@@ -107,12 +114,10 @@ lemmas [simp] =
   iarch_tcb_context_set
   iarch_tcb_set_registers
 
-end
+lemmas [intro!] = idle_global acap_rights_update_id
 
-lemmas [intro!] =  idle_global acap_rights_update_id
-
-lemmas [simp] =  acap_rights_update_id state_hyp_refs_update
-                 tcb_arch_ref_simps hyp_live_tcb_simps hyp_refs_of_simps
+lemmas [simp] = acap_rights_update_id state_hyp_refs_update
+                tcb_arch_ref_simps hyp_live_tcb_simps hyp_refs_of_simps
 
 
 \<comment> \<open>---------------------------------------------------------------------------\<close>
@@ -1686,17 +1691,13 @@ lemma cte_wp_at_pspaceI:
   "\<lbrakk> cte_wp_at P slot s; kheap s = kheap s' \<rbrakk> \<Longrightarrow> cte_wp_at P slot s'"
   by (simp add: cte_wp_at_cases)
 
-context Arch begin
-lemma valid_arch_cap_pspaceI:
+(* generic consequence of architecture-specific details *)
+lemma (in Arch) valid_arch_cap_pspaceI:
   "\<lbrakk> valid_arch_cap acap s; kheap s = kheap s' \<rbrakk> \<Longrightarrow> valid_arch_cap acap s'"
   unfolding valid_arch_cap_def
   by (auto intro: obj_at_pspaceI split: arch_cap.split)
-end
 
-context begin interpretation Arch .
-requalify_facts
-  valid_arch_cap_pspaceI
-end
+requalify_facts Arch.valid_arch_cap_pspaceI
 
 lemma valid_cap_pspaceI:
   "\<lbrakk> s \<turnstile> cap; kheap s = kheap s' \<rbrakk> \<Longrightarrow> s' \<turnstile> cap"
@@ -2953,11 +2954,11 @@ lemma valid_idle_lift:
 
 lemmas caps_of_state_valid_cap = cte_wp_valid_cap [OF caps_of_state_cteD]
 
-
+(* generic consequence of architecture-specific details *)
 lemma (in Arch) obj_ref_is_arch:
   "\<lbrakk>aobj_ref c = Some r; valid_arch_cap c s\<rbrakk> \<Longrightarrow> \<exists> ako. kheap s r = Some (ArchObj ako)"
-by (auto simp add: valid_arch_cap_def obj_at_def valid_arch_cap_ref_def split: arch_cap.splits if_splits)
-
+  by (auto simp: valid_arch_cap_def obj_at_def valid_arch_cap_ref_def
+           split: arch_cap.splits if_splits)
 
 requalify_facts Arch.obj_ref_is_arch
 
@@ -3264,7 +3265,7 @@ lemma invs_sym_refs [elim!]:
   "invs s \<Longrightarrow> sym_refs (state_refs_of s)"
   by (simp add: invs_def valid_state_def valid_pspace_def)
 
-lemma invs_hyp_sym_refs [elim!]: (* ARMHYP move and requalify *)
+lemma invs_hyp_sym_refs [elim!]:
   "invs s \<Longrightarrow> sym_refs (state_hyp_refs_of s)"
   by (simp add: invs_def valid_state_def valid_pspace_def)
 

--- a/proof/invariant-abstract/IpcCancel_AI.thy
+++ b/proof/invariant-abstract/IpcCancel_AI.thy
@@ -8,13 +8,12 @@ theory IpcCancel_AI
 imports ArchSchedule_AI
 begin
 
-context begin interpretation Arch .
-
+(* FIXME arch_split: strange global_naming *)
 requalify_facts
-  arch_stit_invs
-  arch_post_cap_deletion_pred_tcb_at
+  Arch.arch_stit_invs
 
-end
+arch_requalify_facts
+  arch_post_cap_deletion_pred_tcb_at
 
 declare arch_post_cap_deletion_pred_tcb_at[wp]
 

--- a/proof/invariant-abstract/Ipc_AI.thy
+++ b/proof/invariant-abstract/Ipc_AI.thy
@@ -10,25 +10,26 @@ imports
   "Monads.WPBang"
 begin
 
-context begin interpretation Arch .
-requalify_consts
+arch_requalify_consts
   in_device_frame
+
+(* FIXME arch_split: unclear why not arch global_naming *)
 requalify_facts
+  Arch.setup_caller_cap_ioports
+  Arch.set_mrs_ioports
+  Arch.as_user_ioports
+  Arch.set_message_info_ioports
+  Arch.copy_mrs_ioports
+  Arch.store_word_offs_ioports
+  Arch.make_arch_fault_msg_ioports
+  Arch.arch_derive_cap_notzombie
+  Arch.arch_derive_cap_notIRQ
+
+arch_requalify_facts
   lookup_ipc_buffer_inv
   set_mi_invs
   as_user_hyp_refs_of
   valid_arch_arch_tcb_set_registers
-  setup_caller_cap_ioports
-  set_mrs_ioports
-  as_user_ioports
-  set_message_info_ioports
-  copy_mrs_ioports
-  store_word_offs_ioports
-  make_arch_fault_msg_ioports
-  arch_derive_cap_notzombie
-  arch_derive_cap_notIRQ
-
-end
 
 declare lookup_ipc_buffer_inv[wp]
 declare set_mi_invs[wp]

--- a/proof/invariant-abstract/KHeap_AI.thy
+++ b/proof/invariant-abstract/KHeap_AI.thy
@@ -8,15 +8,18 @@ theory KHeap_AI
 imports ArchKHeap_AI
 begin
 
-context begin interpretation Arch .
-
-requalify_consts
+arch_requalify_consts
   obj_is_device
   valid_vso_at
   non_vspace_obj
   vspace_obj_pred
 
+(* FIXME arch_split: these should probably be in an arch-named context *)
 requalify_facts
+  Arch.getActiveIRQ_neq_non_kernel
+  Arch.dmo_getActiveIRQ_non_kernel
+
+arch_requalify_facts
   pspace_in_kernel_window_atyp_lift
   valid_vspace_objs_lift_weak
   vs_lookup_vspace_obj_at_lift
@@ -57,14 +60,9 @@ requalify_facts
   default_arch_object_not_live
   default_tcb_not_live
 
-  getActiveIRQ_neq_non_kernel
-  dmo_getActiveIRQ_non_kernel
-
   valid_arch_tcb_same_type
   valid_arch_tcb_typ_at
   valid_tcb_arch_ref_lift
-
-end
 
 lemmas cap_is_device_obj_is_device[simp] = cap_is_device_obj_is_device
 lemmas storeWord_device_state_hoare[wp] = storeWord_device_state_inv

--- a/proof/invariant-abstract/LevityCatch_AI.thy
+++ b/proof/invariant-abstract/LevityCatch_AI.thy
@@ -13,15 +13,12 @@ begin
 (* FIXME: eliminate mapM_UNIV_wp, use mapM_wp' directly *)
 lemmas mapM_UNIV_wp = mapM_wp'
 
-context begin interpretation Arch .
-
-requalify_consts
+arch_requalify_consts
   ptrFromPAddr addrFromPPtr
-requalify_facts
+
+arch_requalify_facts
   ptrFormPAddr_addFromPPtr
   aobj_ref_arch_cap
-
-end
 
 lemmas aobj_ref_arch_cap_simps[simp] = aobj_ref_arch_cap
 
@@ -46,7 +43,6 @@ lemmas cap_irqs_simps[simp] =
 
 declare liftE_wp[wp]
 declare case_sum_True[simp]
-declare select_singleton[simp]
 
 crunch_ignore (add: do_extended_op)
 

--- a/proof/invariant-abstract/Retype_AI.thy
+++ b/proof/invariant-abstract/Retype_AI.thy
@@ -15,14 +15,12 @@ begin
 abbreviation "up_aligned_area ptr sz \<equiv> {ptr..(ptr && ~~ mask sz) + (2 ^ sz - 1)}"
 abbreviation "down_aligned_area ptr sz \<equiv> {(ptr && ~~ mask sz) + (2 ^ sz - 1) .. ptr}"
 
-context begin interpretation Arch .
-requalify_facts
+arch_requalify_facts
   global_refs_kheap
   valid_vspace_obj_default
-requalify_consts
-  clearMemory
+
+arch_requalify_consts
   clearMemoryVM
-end
 
 declare global_refs_kheap[simp]
 

--- a/proof/invariant-abstract/Schedule_AI.thy
+++ b/proof/invariant-abstract/Schedule_AI.thy
@@ -27,13 +27,11 @@ locale Schedule_AI =
     assumes stit_activatable:
       "\<lbrace>invs\<rbrace> switch_to_idle_thread \<lbrace>\<lambda>rv . (ct_in_state activatable :: 'a state \<Rightarrow> bool)\<rbrace>"
 
-context begin interpretation Arch .
 (* FIXME arch_split: some of these could be moved to generic theories
    so they don't need to be unqualified. *)
 requalify_facts
-  no_irq
-  no_irq_storeWord
-end
+  Arch.no_irq
+  Arch.no_irq_storeWord
 
 crunch schedule_switch_thread_fastfail
   for inv[wp]: P

--- a/proof/invariant-abstract/Syscall_AI.thy
+++ b/proof/invariant-abstract/Syscall_AI.thy
@@ -16,16 +16,18 @@ imports
   ArchInterrupt_AI
 begin
 
-context begin interpretation Arch .
 requalify_facts
-  arch_decode_invocation_inv
-  lookup_cap_and_slot_inv
+  (* lookup_cap_and_slot_inv (* FIXME arch_split: check other arches to make sure this is global *) *)
+  Arch.resetTimer_device_state_inv
+
+arch_requalify_facts (A)
   data_to_cptr_def
+
+arch_requalify_facts
+  arch_decode_invocation_inv
   arch_post_cap_deletion_cur_thread
   arch_post_cap_deletion_state_refs_of
   arch_invoke_irq_handler_typ_at
-  resetTimer_device_state_inv
-end
 
 lemmas [wp] =
   arch_decode_invocation_inv

--- a/proof/invariant-abstract/TcbAcc_AI.thy
+++ b/proof/invariant-abstract/TcbAcc_AI.thy
@@ -8,17 +8,13 @@ theory TcbAcc_AI
 imports ArchCSpace_AI
 begin
 
-context begin interpretation Arch .
-
-requalify_facts
+arch_requalify_facts
   valid_arch_arch_tcb_context_set
   as_user_inv
   getRegister_inv
   user_getreg_inv
 
 declare user_getreg_inv[wp]
-
-end
 
 locale TcbAcc_AI_storeWord_invs =
   fixes state_ext_t :: "'state_ext::state_ext itself"
@@ -1130,7 +1126,6 @@ lemma kheap_Some_state_hyp_refs_ofD:
   "kheap s p = Some ko \<Longrightarrow> state_hyp_refs_of s p = hyp_refs_of ko"
   by (rule ko_at_state_hyp_refs_ofD; simp add: obj_at_def)
 
-(* FIXME should be able to prove this in the generic context *)
 lemma sts_hyp_refs_of[wp]:
   "\<lbrace>\<lambda>s. P (state_hyp_refs_of s)\<rbrace>
     set_thread_state t st

--- a/proof/invariant-abstract/Tcb_AI.thy
+++ b/proof/invariant-abstract/Tcb_AI.thy
@@ -8,12 +8,8 @@ theory Tcb_AI
 imports ArchCNodeInv_AI
 begin
 
-context begin interpretation Arch .
-
-requalify_facts
+arch_requalify_facts
   arch_derive_is_arch
-
-end
 
 locale Tcb_AI_1 =
   fixes state_ext_t :: "('state_ext::state_ext) itself"

--- a/proof/invariant-abstract/Untyped_AI.thy
+++ b/proof/invariant-abstract/Untyped_AI.thy
@@ -15,21 +15,13 @@ begin
 
 unbundle l4v_word_context (* because of Lib.MonadicRewrite *)
 
-context begin interpretation Arch .
-
-requalify_consts
-  region_in_kernel_window
-  arch_default_cap
+arch_requalify_consts
   second_level_tables
   safe_ioport_insert
 
-requalify_facts
-  set_cap_valid_arch_caps_simple
-  set_cap_kernel_window_simple
+arch_requalify_facts
   set_cap_ioports'
   safe_ioport_insert_triv
-
-end
 
 primrec
   valid_untyped_inv_wcap :: "Invocations_A.untyped_invocation \<Rightarrow> cap option
@@ -527,11 +519,6 @@ lemma range_cover_stuff:
     apply (simp add: le_mask_iff[symmetric] mask_def)
     done
   qed (simp add: word_bits_def)
-
-context Arch begin
-  (*FIXME: generify proof that uses this *)
-  lemmas range_cover_stuff_arch = range_cover_stuff[unfolded word_bits_def, simplified]
-end
 
 
 lemma cte_wp_at_range_cover:

--- a/proof/invariant-abstract/VSpacePre_AI.thy
+++ b/proof/invariant-abstract/VSpacePre_AI.thy
@@ -12,12 +12,8 @@ theory VSpacePre_AI
 imports ArchTcbAcc_AI
 begin
 
-context begin interpretation Arch .
-
-requalify_facts
+arch_requalify_facts
   cap_master_cap_tcb_cap_valid_arch
-
-end
 
 lemma throw_on_false_wp[wp]:
   "\<lbrace>P\<rbrace> f \<lbrace>\<lambda>rv s. (rv \<longrightarrow> Q () s) \<and> (\<not> rv \<longrightarrow> E x s)\<rbrace>

--- a/proof/invariant-abstract/VSpace_AI.thy
+++ b/proof/invariant-abstract/VSpace_AI.thy
@@ -11,14 +11,14 @@ Architecture-independent VSpace invariant proofs
 theory VSpace_AI
 imports ArchVSpace_AI
 begin
-context begin interpretation Arch .
 
+(* FIXME arch_split: this should maybe have global_naming *)
 requalify_facts
-   pspace_respects_device_region_dmo
-   cap_refs_respects_device_region_dmo
-   ackInterrupt_device_state_inv
+  Arch.ackInterrupt_device_state_inv
 
-end
+arch_requalify_facts
+  pspace_respects_device_region_dmo
+  cap_refs_respects_device_region_dmo
 
 lemmas device_region_dmos = pspace_respects_device_region_dmo
 


### PR DESCRIPTION
🦆🦆🦆 Temporarily only dealing with AARCH64; want feedback before applying to other arches. 
(this is on top of the requalify changes that are not yet merged, will re-target to `l4v` once they are).

This yields a performance improvement (possibly due to `context begin interpretation Arch .` not being parallalisable by Isabelle):
```
AInvs after deploying tweaks:
glow: ( 0:13:50 real,  1:15:34 cpu, 13.13GB)
      ( 0:14:07 real,  1:16:58 cpu, 17.06GB)
pcr:  ( 0:08:30 real,  0:44:48 cpu, 16.97GB)

AInvs before requalify tricks:
glow: ( 0:17:17 real,  1:24:48 cpu, 16.01GB)
      ( 0:17:15 real,  1:25:41 cpu, 17.21GB)
pcr:  ( 0:14:13 real,  1:07:29 cpu, 10.46GB)
```

Here's what I changed:
* global_naming AARCH64 -> arch_global_naming
* try get rid of `interpretation Arch .` (slow) in lieu of `(in Arch)` (faster) or proper requalifying (nearly instant)
* get rid of requalifications that were already requalified, or were global (thanks to new warnings) TODO: some of these will turn out to be broken because they're not actually global/exported on other arches
* put arch_global_naming on same line as `context Arch begin`
* annotate requalifications in Arch theories that can be moved to generic
* put FIXMEs on unusual global_naming practices